### PR TITLE
Bump workflow 'hramos/needs-attention' to `v2.0.0-rc.2`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Apply Needs Attention Label
-        uses: hramos/needs-attention@v2.0.0-rc.1
+        uses: hramos/needs-attention@v2.0.0-rc.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # response-required-label: 'Needs Author Feedback' # <- Default


### PR DESCRIPTION
`v2.0.0-rc.2` fixes regression with gh secret token name
Bump workflow 'hramos/needs-attention' to `v2.0.0-rc.2` 