### PR TITLE
Bump workflow `hramos/needs-attention` to `v2.0.0` i.e. `latest`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Apply Needs Attention Label
-        uses: hramos/needs-attention@v2.0.0-rc.2
+        uses: hramos/needs-attention@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # response-required-label: 'Needs Author Feedback' # <- Default


### PR DESCRIPTION
## Summary

Bump workflow `hramos/needs-attention` to `v2.0.0`
`v2.0.0` is a new **BREAKING** release with a number of improvements.

- Full Changelog for `v2.0.0`: https://github.com/hramos/needs-attention/releases/tag/v2.0.0 
- Marketplace `v2.0.0`: https://github.com/marketplace/actions/needs-attention?version=v2.0.0

## Test Plan

- Workflow should add and remove respective labels as usual.