### PR TITLE
Update readme to use actions/checkout@v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ jobs:
     name: Apply Needs Attention Label
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Apply Needs Attention Label
-        uses: hramos/needs-attention@v1
+        uses: hramos/needs-attention@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -50,7 +50,7 @@ jobs:
 Configuring labels:
 
 ```
-uses: hramos/needs-attention@v1
+uses: hramos/needs-attention@v2
 with:
     repo-token: ${{ secrets.GITHUB_TOKEN }}
     response-required-label: 'Needs Author Feedback'


### PR DESCRIPTION
Node.js 16 actions are deprecated. 
Please update the following actions to use Node.js 20: actions/checkout@v3. 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
