### PR TITLE
[BREAKING] Bump Node.js to v20.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
   result:
     description: 'A string description of any actions taken.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/index.js'
 branding:
   icon: 'flag'


### PR DESCRIPTION
Node.js 16 actions are deprecated. 
Please update the following actions to use Node.js 20: hramos/needs-attention@v2.

 For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This is a pull request template.
